### PR TITLE
Elaborate on --no-quarantine requirements when upgrading

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ Installing talosctl from this cask is simple:
 `--no-quarantine` is flag is required as `talosctl` is not
 [notarized](https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution) yet.
 
+Note that the arguments must be passed when upgrading as well:
+
+- `brew upgrade --cask --no-quarantine talosctl`
+
+If you accidentally upgrade the forumla without the `--no-quarantine` argument you may have to reinstall talosctl:
+
+- `brew reinstall --cask --no-quarantine talosctl`
+
 ## Updates
 
 Currently, updates of this repository are manual


### PR DESCRIPTION
I got into a weird place after I ran `brew upgrade talosctl` without further arguments. I had a collegue of mine verify that doing `upgrade` with the appropriate arguments works so thought it would be worth being explicit about it in the README.

It really would be great if we could just get this properly signed once and for all :)

Also for the record: I couldn't get `talosctl` to work by manually allowing it in the Security & Privacy tab in MacOS, it just kept on giving me the "unverified developer" popup.